### PR TITLE
feat: add cloudnative-pg

### DIFF
--- a/sources/cloudnative-pg/vendir.yaml
+++ b/sources/cloudnative-pg/vendir.yaml
@@ -1,0 +1,12 @@
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: cloudnative-pg
+        githubRelease:
+          slug: cloudnative-pg/cloudnative-pg
+          tag: v1.29.1
+          assetNames:
+            - cnpg-\d+\.\d+\.\d+\.yaml
+          disableAutoChecksumValidation: true


### PR DESCRIPTION
Adding cloud native-pg crds.
It not clear from the vendir docs, but I assume `assetNames` supports regex.