### PR TITLE
feat: publish non-CRD schemas via extras tree

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,17 +19,18 @@ jobs:
         with:
           patterns: |-
             sources/**/vendir.yml
+            extras/**/vendir.yml
             scripts/**
             .mise.toml
             .github/workflows/pull-request.yaml
 
       - name: Build matrix
         id: matrix
-        # Any non-source change (scripts, mise, workflow) rebuilds every source.
+        # Any non-source change (scripts, mise, workflow) rebuilds everything.
         run: |
           changed='${{ steps.changed-files.outputs.changed_files }}'
-          if jq -e 'any(.[]; test("^sources/[^/]+/[^/]+/vendir\\.yml$") | not)' <<< "$changed" > /dev/null; then
-            mapfile -t candidates < <(printf '%s\n' sources/*/*/vendir.yml)
+          if jq -e 'any(.[]; test("^(sources|extras)/[^/]+/[^/]+/vendir\\.yml$") | not)' <<< "$changed" > /dev/null; then
+            mapfile -t candidates < <(printf '%s\n' sources/*/*/vendir.yml extras/*/*/vendir.yml)
           else
             mapfile -t candidates < <(jq -r '.[]' <<< "$changed")
           fi
@@ -39,11 +40,16 @@ jobs:
           done
           matrix=$(jq -c '
             [ .[]
-              | (split("/") | .[1:3]) as $p
+              | (split("/")) as $s
+              | $s[0] as $root
+              | ($s[1:3]) as $p
               | {
-                  name: ($p | join("/")),
-                  dir:  ("sources/" + ($p | join("/"))),
-                  out:  ("out/crds/" + ($p | join("__")) + ".yaml")
+                  name: ($root + "/" + ($p | join("/"))),
+                  kind: (if $root == "sources" then "source" else "extra" end),
+                  dir:  ($root + "/" + ($p | join("/"))),
+                  out:  (if $root == "sources"
+                          then "out/crds/" + ($p | join("__")) + ".yaml"
+                          else "out/site/extras/" + ($p | join("/")) end)
                 }
             ] | unique_by(.name)
           ' <<< "$paths")
@@ -73,10 +79,14 @@ jobs:
         with:
           experimental: true
 
-      - name: Extract CRDs
+      - name: Vendor
         env:
           VENDIR_GITHUB_API_TOKEN: ${{ github.token }}
-        run: mise run build "${{ matrix.source.dir }}" "${{ matrix.source.out }}"
+        run: |
+          case "${{ matrix.source.kind }}" in
+            source) mise run build "${{ matrix.source.dir }}" "${{ matrix.source.out }}" ;;
+            extra)  mise run extra "${{ matrix.source.dir }}" "${{ matrix.source.out }}" ;;
+          esac
 
   status:
     if: ${{ !cancelled() }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - "main"
     paths:
       - "sources/**/vendir.yml"
+      - "extras/**/vendir.yml"
       - "scripts/**"
       - ".mise.toml"
       - ".github/workflows/release.yaml"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 out/
 sources/**/vendor/
 sources/**/vendir.lock.yml
+extras/**/vendor/
+extras/**/vendir.lock.yml

--- a/.mise.toml
+++ b/.mise.toml
@@ -17,8 +17,12 @@ OUT_DIR = "{{config_root}}/out"
 description = "Extract CRDs from one source (usage: mise run build <source-dir> <output-file>)"
 run = "./scripts/build.sh"
 
+[tasks.extra]
+description = "Vendor one extras source (usage: mise run extra <source-dir> <output-dir>)"
+run = "./scripts/extras.sh"
+
 [tasks.all]
-description = "Build every source and render the site locally"
+description = "Build every source, render the site, and stage extras"
 run = """
 set -eu
 rm -rf "$OUT_DIR"
@@ -28,6 +32,10 @@ for dir in sources/*/*/; do
   ./scripts/build.sh "$dir" "$OUT_DIR/crds/$name.yaml"
 done
 crd-schema-publisher convert -d "$OUT_DIR/crds" -o "$OUT_DIR/site" --render
+for dir in extras/*/*/; do
+  name=$(basename "$(dirname "$dir")")/$(basename "$dir")
+  ./scripts/extras.sh "$dir" "$OUT_DIR/site/extras/$name"
+done
 """
 
 [tasks.clean]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ The [Red Hat YAML extension](https://marketplace.visualstudio.com/items?itemName
 for VS Code and most other YAML language-server integrations honor this
 comment.
 
+## Extras
+
+A small `extras/` tree lets the same pipeline publish hand-curated JSON
+schemas that aren't CRDs (e.g. the bjw-s app-template HelmRelease schema).
+Each source uses the same `vendir.yml` shape as the CRD sources but the
+build copies the selected files verbatim into `out/site/extras/<owner>/<name>/`.
+Use this for narrow, schema-shaped artifacts only — anything that needs
+rendering or transformation belongs upstream.
+
 ## Contributing
 
 To add a new upstream CRD source:

--- a/extras/bjw-s-labs/app-template/vendir.yml
+++ b/extras/bjw-s-labs/app-template/vendir.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/bjw-s-labs/helm-charts
+          ref: app-template-5.0.1
+        includePaths:
+          - charts/other/app-template/schemas/*.schema.json

--- a/scripts/extras.sh
+++ b/scripts/extras.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Vendor non-CRD JSON Schema assets from a single source into a flat output dir.
+# Usage: extras.sh <source-dir> <output-dir>
+#
+# Reads <source-dir>/vendir.yml, runs `vendir sync` in a scratch dir, and
+# copies every regular file the upstream config selected (via includePaths or
+# asset names) into <output-dir> with its basename. The output is the path
+# served at /extras/<owner>/<name>/ on the published site.
+
+set -euo pipefail
+shopt -s globstar nullglob
+
+SOURCE_DIR="${1:?usage: extras.sh <source-dir> <output-dir>}"
+OUTPUT_DIR="${2:?usage: extras.sh <source-dir> <output-dir>}"
+
+SOURCE_DIR="$(cd "${SOURCE_DIR%/}" && pwd)"
+
+mkdir -p "$OUTPUT_DIR"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp "$SOURCE_DIR/vendir.yml" "$WORK/"
+vendir sync --chdir "$WORK" >&2
+
+# vendir auto-includes top-level LICENSE/README from git sources; skip them.
+mapfile -t files < <(find "$WORK/vendor" -mindepth 2 -type f)
+if (( ${#files[@]} == 0 )); then
+  echo "vendir produced no files for $SOURCE_DIR" >&2
+  exit 1
+fi
+
+cp -t "$OUTPUT_DIR" "${files[@]}"


### PR DESCRIPTION
## Summary

- New `extras/` top-level tree, parallel to `sources/`, for hand-curated JSON schemas that aren't CRDs.
- `scripts/extras.sh` mirrors `build.sh`'s shape: vendir-sync, flatten the vendor tree, copy files into a per-source output dir. Top-level files vendir auto-adds for git sources (LICENSE, README) are skipped.
- `.mise.toml` gains a single-source `extra` task plus an extras pass appended to `all`.
- First consumer: `extras/bjw-s-labs/app-template/vendir.yml` (pinned to `app-template-5.0.1`) — publishes the two app-template HelmRelease schemas at `out/site/extras/bjw-s-labs/app-template/`.
- PR workflow matrix is now kind-aware: each entry carries `kind: source|extra` and dispatches to the right `mise run` command. Validated against four scenarios (source-only / extras-only / infra-rebuilds-all / deleted-path).
- Release workflow paths include `extras/**/vendir.yml`.

## Test plan

- [x] `mise run all` produces 475 CRDs + 2 extra schemas locally.
- [x] PR matrix jq verified for: single source change, single extras change, scripts/ change (rebuilds all 33 entries with both kinds), deleted source path (zero entries).
- [ ] CI green on this PR.