### PR TITLE
feat: bash yaml-schema hook for lefthook

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,6 +7,25 @@ on:
   pull_request:
 
 jobs:
+  hook:
+    name: Hook tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          experimental: true
+
+      - name: Run hook tests
+        run: bash hooks/test-k8s-yaml-schema.sh
+
   changed:
     name: Discover changed sources
     runs-on: ubuntu-latest
@@ -96,7 +115,8 @@ jobs:
   status:
     if: ${{ !cancelled() }}
     needs:
-      - "build"
+      - hook
+      - build
     name: Build Success
     runs-on: ubuntu-latest
     steps:

--- a/.k8s-schema-hook.example.yaml
+++ b/.k8s-schema-hook.example.yaml
@@ -1,22 +1,13 @@
 ---
 # Schema host. The hook writes URLs of the form
 #   https://<domain>/<apiGroup>/<kind_lowercase>_<apiVersion>.json
-# unless an override matches first.
+# unless an override matches first. Core resources (apiVersion without a
+# group, like `v1` or `apps/v1`) are always skipped.
 domain: k8s-schemas.home-operations.com
 
-# Optional. Default false. When true, the hook also writes directives for core
-# resources (apiVersion without a group, like `v1` or `apps/v1`).
-include_core: false
-
-# Optional. Default `core`. Used as the {apiGroup} placeholder for core resources.
-core_group: core
-
-# Optional. Defaults to the URL pattern shown above. Placeholders:
-#   {domain} {apiGroup} {apiVersion} {kind} {kind_lowercase}
-# schema_template: "https://{domain}/{apiGroup}/{kind_lowercase}_{apiVersion}.json"
-
-# Per-rule overrides. First match wins. The `schema` field may use the same
-# placeholders as `schema_template`; rules without `{` are treated as literals.
+# Per-rule overrides. First match wins. Match keys: `kind`, `apiGroup`,
+# `chartRefOciUrl`. The `schema` field may use {domain} {apiGroup}
+# {apiVersion} {kind} {kind_lowercase} placeholders.
 overrides:
   # Use schemastore's kustomization schema instead of synthesising one.
   - name: kustomize
@@ -25,17 +16,9 @@ overrides:
     schema: https://json.schemastore.org/kustomization
 
   # When a HelmRelease's chartRef points at the bjw-s app-template OCI chart,
-  # swap in the self-contained schema this repo composes (the values block is
-  # fully inlined, so editors don't need to follow cross-document $refs).
+  # swap in the self-contained schema this repo composes.
   - name: helmrelease-app-template
     match:
       kind: HelmRelease
       chartRefOciUrl: oci://ghcr.io/bjw-s-labs/helm/app-template
     schema: https://{domain}/extras/bjw-s-labs/app-template/helmrelease-helm-v2.schema.json
-
-  # Example: route by file path instead of apiVersion.
-  # - name: prometheusrule-by-path
-  #   match:
-  #     file_regex: /prometheus/.*\.yaml$
-  #     kind: PrometheusRule
-  #   schema: https://example.com/prometheusrule.schema.json

--- a/.k8s-schema-hook.example.yaml
+++ b/.k8s-schema-hook.example.yaml
@@ -1,0 +1,41 @@
+---
+# Schema host. The hook writes URLs of the form
+#   https://<domain>/<apiGroup>/<kind_lowercase>_<apiVersion>.json
+# unless an override matches first.
+domain: k8s-schemas.home-operations.com
+
+# Optional. Default false. When true, the hook also writes directives for core
+# resources (apiVersion without a group, like `v1` or `apps/v1`).
+include_core: false
+
+# Optional. Default `core`. Used as the {apiGroup} placeholder for core resources.
+core_group: core
+
+# Optional. Defaults to the URL pattern shown above. Placeholders:
+#   {domain} {apiGroup} {apiVersion} {kind} {kind_lowercase}
+# schema_template: "https://{domain}/{apiGroup}/{kind_lowercase}_{apiVersion}.json"
+
+# Per-rule overrides. First match wins. The `schema` field may use the same
+# placeholders as `schema_template`; rules without `{` are treated as literals.
+overrides:
+  # Use schemastore's kustomization schema instead of synthesising one.
+  - name: kustomize
+    match:
+      apiGroup: kustomize.config.k8s.io
+    schema: https://json.schemastore.org/kustomization
+
+  # When a HelmRelease's chartRef points at the bjw-s app-template OCI chart,
+  # swap in the self-contained schema this repo composes (the values block is
+  # fully inlined, so editors don't need to follow cross-document $refs).
+  - name: helmrelease-app-template
+    match:
+      kind: HelmRelease
+      chartRefOciUrl: oci://ghcr.io/bjw-s-labs/helm/app-template
+    schema: https://{domain}/extras/bjw-s-labs/app-template/helmrelease-helm-v2.schema.json
+
+  # Example: route by file path instead of apiVersion.
+  # - name: prometheusrule-by-path
+  #   match:
+  #     file_regex: /prometheus/.*\.yaml$
+  #     kind: PrometheusRule
+  #   schema: https://example.com/prometheusrule.schema.json

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ curl -sLO https://raw.githubusercontent.com/home-operations/k8s-schemas/main/hoo
 chmod +x k8s-yaml-schema && mv k8s-yaml-schema hooks/
 ```
 
-Overrides match on `kind`, `apiGroup`, `apiVersion`, file path regex, or
-a HelmRelease's `chartRef` OCI URL — see the example config for the
-vocabulary.
+Overrides match on `kind`, `apiGroup`, or a HelmRelease's `chartRef` OCI
+URL (resolved against a sidecar `ocirepository.yaml`). See the example
+config.
 
 ## Extras
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,37 @@ The [Red Hat YAML extension](https://marketplace.visualstudio.com/items?itemName
 for VS Code and most other YAML language-server integrations honor this
 comment.
 
+### As a git hook
+
+This repo also ships [`hooks/k8s-yaml-schema`](hooks/k8s-yaml-schema) — a
+small bash script that walks your YAML files, derives the right schema URL
+from each document's `apiVersion`/`kind`, and inserts or updates the
+`# yaml-language-server: $schema=...` directive in place. Dependencies are
+`bash`, `yq` (mikefarah), `jq`, and `awk` — most repos already pull these
+in via mise/aqua.
+
+Copy [`.k8s-schema-hook.example.yaml`](.k8s-schema-hook.example.yaml) to
+your repo as `.k8s-schema-hook.yaml`, point `domain:` at your published
+site, vendor the script (one curl is enough), and wire it into
+[lefthook](https://lefthook.dev):
+
+```toml
+# .lefthook.toml
+[pre-commit.commands.k8s-yaml-schema]
+glob = ["kubernetes/**/*.yaml", "kubernetes/**/*.yml"]
+run = "hooks/k8s-yaml-schema --config .k8s-schema-hook.yaml {staged_files}"
+stage_fixed = true
+```
+
+```sh
+curl -sLO https://raw.githubusercontent.com/home-operations/k8s-schemas/main/hooks/k8s-yaml-schema
+chmod +x k8s-yaml-schema && mv k8s-yaml-schema hooks/
+```
+
+Overrides match on `kind`, `apiGroup`, `apiVersion`, file path regex, or
+a HelmRelease's `chartRef` OCI URL — see the example config for the
+vocabulary.
+
 ## Extras
 
 A small `extras/` tree lets the same pipeline publish hand-curated JSON

--- a/hooks/k8s-yaml-schema
+++ b/hooks/k8s-yaml-schema
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# k8s-yaml-schema — insert or update yaml-language-server $schema directives in
+# Kubernetes YAML manifests based on each document's apiVersion/kind.
+#
+# Usage:
+#   k8s-yaml-schema [--config <path>] [--] <file>...
+#
+# Exit codes:
+#   0   no files were modified
+#   1   at least one file was rewritten (hook style: re-stage and re-run)
+#   2   configuration or input error
+#
+# Dependencies: bash, yq (mikefarah), jq, awk.
+set -euo pipefail
+
+CONFIG=".k8s-schema-hook.yaml"
+FILES=()
+
+while (($#)); do
+  case "$1" in
+    --config) CONFIG="$2"; shift 2 ;;
+    --config=*) CONFIG="${1#*=}"; shift ;;
+    -h|--help) sed -n '2,/^set -/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    --) shift; FILES+=("$@"); break ;;
+    -*) echo "k8s-yaml-schema: unknown option: $1" >&2; exit 2 ;;
+    *) FILES+=("$1"); shift ;;
+  esac
+done
+
+if [[ ! -f $CONFIG ]]; then
+  echo "k8s-yaml-schema: config not found: $CONFIG" >&2
+  exit 2
+fi
+
+DOMAIN=$(yq -r '.domain // ""' "$CONFIG")
+if [[ -z $DOMAIN || $DOMAIN == null ]]; then
+  echo "k8s-yaml-schema: missing 'domain' in $CONFIG" >&2
+  exit 2
+fi
+DOMAIN=${DOMAIN#https://}; DOMAIN=${DOMAIN#http://}; DOMAIN=${DOMAIN%/}
+
+INCLUDE_CORE=$(yq -r '.include_core // false' "$CONFIG")
+CORE_GROUP=$(yq -r '.core_group // "core"' "$CONFIG")
+TEMPLATE=$(yq -r '.schema_template // "https://{domain}/{apiGroup}/{kind_lowercase}_{apiVersion}.json"' "$CONFIG")
+OVERRIDES=$(yq -o=json '.overrides // []' "$CONFIG")
+
+# Render placeholders in a URL template.
+render() {
+  local t=$1 g=$2 v=$3 k=$4 lc=${4,,}
+  t=${t//\{domain\}/$DOMAIN}
+  t=${t//\{apiGroup\}/$g}
+  t=${t//\{apiVersion\}/$v}
+  t=${t//\{kind\}/$k}
+  t=${t//\{kind_lowercase\}/$lc}
+  t=${t//\{kind_lower\}/$lc}
+  printf '%s' "$t"
+}
+
+# Look up the chartRef's OCIRepository URL from a sidecar file alongside `$file`.
+chart_ref_oci_url() {
+  local file=$1 idx=$2 ref_name dir sidecar
+  ref_name=$(yq -r "select(di == $idx) | .spec.chartRef // {} | select(.kind == \"OCIRepository\") | .name // \"\"" "$file" 2>/dev/null || true)
+  [[ -z $ref_name || $ref_name == null ]] && return 0
+  dir=$(dirname "$file")
+  for sidecar in "$dir/ocirepository.yaml" "$dir/ocirepository.yml"; do
+    [[ -f $sidecar ]] || continue
+    yq -r ". | select(.kind == \"OCIRepository\" and .metadata.name == \"$ref_name\") | .spec.url // \"\"" "$sidecar" 2>/dev/null | head -1
+    return 0
+  done
+}
+
+# Compute the desired schema URL for a single doc.
+choose_schema() {
+  local file=$1 idx=$2 av=$3 kind=$4 group ver
+  if [[ $av == */* ]]; then group=${av%%/*}; ver=${av##*/}
+  else group=$CORE_GROUP; ver=$av; fi
+
+  local n i rule schema
+  n=$(jq 'length' <<< "$OVERRIDES")
+  for ((i=0; i<n; i++)); do
+    rule=$(jq -c ".[$i]" <<< "$OVERRIDES")
+    local mkind mgroup mver mfile_regex mchart
+    mkind=$(jq -r       '.match.kind            // empty' <<< "$rule")
+    mgroup=$(jq -r      '.match.apiGroup        // empty' <<< "$rule")
+    mver=$(jq -r        '.match.apiVersion      // empty' <<< "$rule")
+    mfile_regex=$(jq -r '.match.file_regex      // empty' <<< "$rule")
+    mchart=$(jq -r      '.match.chartRefOciUrl  // empty' <<< "$rule")
+
+    [[ -n $mkind  && $mkind  != "$kind"  ]] && continue
+    [[ -n $mgroup && $mgroup != "$group" ]] && continue
+    [[ -n $mver   && $mver   != "$ver"   ]] && continue
+    [[ -n $mfile_regex ]] && { [[ $file =~ $mfile_regex ]] || continue; }
+    if [[ -n $mchart ]]; then
+      local actual; actual=$(chart_ref_oci_url "$file" "$idx")
+      [[ $actual == "$mchart" ]] || continue
+    fi
+
+    schema=$(jq -r '.schema' <<< "$rule")
+    if [[ $schema == *"{"* ]]; then render "$schema" "$group" "$ver" "$kind"
+    else printf '%s' "$schema"; fi
+    return 0
+  done
+
+  render "$TEMPLATE" "$group" "$ver" "$kind"
+}
+
+# Insert or update the directive at the start of each doc.
+# Reads per-doc URLs from `urls_file` (one per line; empty line = no change).
+apply_directives() {
+  local file=$1 urls_file=$2
+  awk -v urls_file="$urls_file" '
+    BEGIN {
+      i = 0
+      while ((getline line < urls_file) > 0) urls[i++] = line
+      close(urls_file)
+      doc = 0; leading = 1; placed = 0
+    }
+    function emit(    u) {
+      u = urls[doc]
+      if (u != "" && !placed) { print "# yaml-language-server: $schema=" u; placed = 1 }
+    }
+    /^---[ \t]*$/ {
+      if (leading) emit()
+      print
+      doc++; leading = 1; placed = 0
+      next
+    }
+    leading && !placed && /^[[:space:]]*#[[:space:]]*yaml-language-server:[[:space:]]*[$]schema=/ {
+      cur = $0
+      sub(/.*[$]schema=/, "", cur)
+      sub(/[[:space:]]+$/, "", cur)
+      if (cur == urls[doc])      print
+      else if (urls[doc] != "")  print "# yaml-language-server: $schema=" urls[doc]
+      else                       print
+      placed = 1; leading = 0
+      next
+    }
+    leading && /^[[:space:]]*($|#)/ { print; next }
+    leading {
+      emit()
+      leading = 0
+      print
+      next
+    }
+    { print }
+    END { if (leading) emit() }
+  ' "$file"
+}
+
+process_file() {
+  local file=$1
+  local urls=() doc=0 line av kind
+  while IFS= read -r line; do
+    [[ -z $line ]] && { urls+=(""); doc=$((doc+1)); continue; }
+    av=$(jq -r '.av   // ""' <<< "$line")
+    kind=$(jq -r '.kind // ""' <<< "$line")
+    if [[ -z $av || -z $kind || $av == null || $kind == null ]]; then
+      urls+=("")
+    elif [[ $av != */* && $INCLUDE_CORE != "true" ]]; then
+      urls+=("")
+    else
+      urls+=("$(choose_schema "$file" "$doc" "$av" "$kind")")
+    fi
+    doc=$((doc+1))
+  done < <(yq -o=json -I=0 '{"av": (.apiVersion // ""), "kind": (.kind // "")}' "$file" 2>/dev/null || true)
+
+  ((${#urls[@]})) || return 0
+
+  local urls_file tmp
+  urls_file=$(mktemp); printf '%s\n' "${urls[@]}" > "$urls_file"
+  tmp=$(mktemp)
+  apply_directives "$file" "$urls_file" > "$tmp"
+  rm -f "$urls_file"
+
+  if cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+    return 0
+  fi
+  mv "$tmp" "$file"
+  return 1
+}
+
+changed=0; errors=0
+for file in "${FILES[@]}"; do
+  [[ -f $file ]] || continue
+  rc=0
+  process_file "$file" || rc=$?
+  case $rc in
+    0) : ;;
+    1) changed=1; echo "k8s-yaml-schema: updated $file" >&2 ;;
+    *) errors=$((errors+1)); echo "k8s-yaml-schema: error processing $file" >&2 ;;
+  esac
+done
+
+(( errors > 0 )) && exit 2
+(( changed )) && exit 1 || exit 0

--- a/hooks/k8s-yaml-schema
+++ b/hooks/k8s-yaml-schema
@@ -2,195 +2,137 @@
 # k8s-yaml-schema — insert or update yaml-language-server $schema directives in
 # Kubernetes YAML manifests based on each document's apiVersion/kind.
 #
-# Usage:
-#   k8s-yaml-schema [--config <path>] [--] <file>...
-#
-# Exit codes:
-#   0   no files were modified
-#   1   at least one file was rewritten (hook style: re-stage and re-run)
-#   2   configuration or input error
-#
-# Dependencies: bash, yq (mikefarah), jq, awk.
+# Usage: k8s-yaml-schema [--config <path>] <file>...
+# Exit:  0 unchanged | 1 modified | 2 error
+# Deps:  bash, yq (mikefarah), jq, awk
 set -euo pipefail
 
 CONFIG=".k8s-schema-hook.yaml"
 FILES=()
-
 while (($#)); do
-  case "$1" in
-    --config) CONFIG="$2"; shift 2 ;;
-    --config=*) CONFIG="${1#*=}"; shift ;;
-    -h|--help) sed -n '2,/^set -/p' "$0" | sed 's/^# \?//'; exit 0 ;;
-    --) shift; FILES+=("$@"); break ;;
-    -*) echo "k8s-yaml-schema: unknown option: $1" >&2; exit 2 ;;
-    *) FILES+=("$1"); shift ;;
+  case $1 in
+    --config) CONFIG=$2; shift 2 ;;
+    --help)   sed -n '2,/^set -/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *)        FILES+=("$1"); shift ;;
   esac
 done
 
-if [[ ! -f $CONFIG ]]; then
-  echo "k8s-yaml-schema: config not found: $CONFIG" >&2
-  exit 2
-fi
+[[ -f $CONFIG ]] || { echo "k8s-yaml-schema: config not found: $CONFIG" >&2; exit 2; }
 
 DOMAIN=$(yq -r '.domain // ""' "$CONFIG")
-if [[ -z $DOMAIN || $DOMAIN == null ]]; then
-  echo "k8s-yaml-schema: missing 'domain' in $CONFIG" >&2
-  exit 2
-fi
+[[ -n $DOMAIN && $DOMAIN != null ]] || { echo "k8s-yaml-schema: missing 'domain' in $CONFIG" >&2; exit 2; }
 DOMAIN=${DOMAIN#https://}; DOMAIN=${DOMAIN#http://}; DOMAIN=${DOMAIN%/}
 
-INCLUDE_CORE=$(yq -r '.include_core // false' "$CONFIG")
-CORE_GROUP=$(yq -r '.core_group // "core"' "$CONFIG")
-TEMPLATE=$(yq -r '.schema_template // "https://{domain}/{apiGroup}/{kind_lowercase}_{apiVersion}.json"' "$CONFIG")
 OVERRIDES=$(yq -o=json '.overrides // []' "$CONFIG")
 
-# Render placeholders in a URL template.
 render() {
-  local t=$1 g=$2 v=$3 k=$4 lc=${4,,}
+  # render <template> <group> <ver> <kind>
+  local t=$1 lc=${4,,}
   t=${t//\{domain\}/$DOMAIN}
-  t=${t//\{apiGroup\}/$g}
-  t=${t//\{apiVersion\}/$v}
-  t=${t//\{kind\}/$k}
+  t=${t//\{apiGroup\}/$2}
+  t=${t//\{apiVersion\}/$3}
+  t=${t//\{kind\}/$4}
   t=${t//\{kind_lowercase\}/$lc}
-  t=${t//\{kind_lower\}/$lc}
   printf '%s' "$t"
 }
 
-# Look up the chartRef's OCIRepository URL from a sidecar file alongside `$file`.
 chart_ref_oci_url() {
-  local file=$1 idx=$2 ref_name dir sidecar
-  ref_name=$(yq -r "select(di == $idx) | .spec.chartRef // {} | select(.kind == \"OCIRepository\") | .name // \"\"" "$file" 2>/dev/null || true)
-  [[ -z $ref_name || $ref_name == null ]] && return 0
-  dir=$(dirname "$file")
-  for sidecar in "$dir/ocirepository.yaml" "$dir/ocirepository.yml"; do
-    [[ -f $sidecar ]] || continue
-    yq -r ". | select(.kind == \"OCIRepository\" and .metadata.name == \"$ref_name\") | .spec.url // \"\"" "$sidecar" 2>/dev/null | head -1
-    return 0
+  # chart_ref_oci_url <file> <doc_idx>
+  local ref dir s
+  ref=$(yq -r "select(di == $2) | .spec.chartRef // {} | select(.kind == \"OCIRepository\") | .name // \"\"" "$1" 2>/dev/null || true)
+  [[ -n $ref && $ref != null ]] || return 0
+  dir=$(dirname "$1")
+  for s in "$dir/ocirepository.yaml" "$dir/ocirepository.yml"; do
+    [[ -f $s ]] && yq -r ". | select(.kind == \"OCIRepository\" and .metadata.name == \"$ref\") | .spec.url // \"\"" "$s" 2>/dev/null | head -1 && return 0
   done
 }
 
-# Compute the desired schema URL for a single doc.
 choose_schema() {
-  local file=$1 idx=$2 av=$3 kind=$4 group ver
-  if [[ $av == */* ]]; then group=${av%%/*}; ver=${av##*/}
-  else group=$CORE_GROUP; ver=$av; fi
+  # choose_schema <file> <doc_idx> <apiVersion> <kind>
+  local av=$3
+  [[ $av == */* ]] || return 0   # skip core resources (no apiGroup)
+  local group=${av%%/*} ver=${av##*/}
 
-  local n i rule schema
+  local n j rule mk mg mc actual schema
   n=$(jq 'length' <<< "$OVERRIDES")
-  for ((i=0; i<n; i++)); do
-    rule=$(jq -c ".[$i]" <<< "$OVERRIDES")
-    local mkind mgroup mver mfile_regex mchart
-    mkind=$(jq -r       '.match.kind            // empty' <<< "$rule")
-    mgroup=$(jq -r      '.match.apiGroup        // empty' <<< "$rule")
-    mver=$(jq -r        '.match.apiVersion      // empty' <<< "$rule")
-    mfile_regex=$(jq -r '.match.file_regex      // empty' <<< "$rule")
-    mchart=$(jq -r      '.match.chartRefOciUrl  // empty' <<< "$rule")
-
-    [[ -n $mkind  && $mkind  != "$kind"  ]] && continue
-    [[ -n $mgroup && $mgroup != "$group" ]] && continue
-    [[ -n $mver   && $mver   != "$ver"   ]] && continue
-    [[ -n $mfile_regex ]] && { [[ $file =~ $mfile_regex ]] || continue; }
-    if [[ -n $mchart ]]; then
-      local actual; actual=$(chart_ref_oci_url "$file" "$idx")
-      [[ $actual == "$mchart" ]] || continue
+  for ((j=0; j<n; j++)); do
+    rule=$(jq -c ".[$j]" <<< "$OVERRIDES")
+    mk=$(jq -r '.match.kind // empty'           <<< "$rule")
+    mg=$(jq -r '.match.apiGroup // empty'       <<< "$rule")
+    mc=$(jq -r '.match.chartRefOciUrl // empty' <<< "$rule")
+    [[ -n $mk && $mk != "$4"     ]] && continue
+    [[ -n $mg && $mg != "$group" ]] && continue
+    if [[ -n $mc ]]; then
+      actual=$(chart_ref_oci_url "$1" "$2")
+      [[ $actual == "$mc" ]] || continue
     fi
-
     schema=$(jq -r '.schema' <<< "$rule")
-    if [[ $schema == *"{"* ]]; then render "$schema" "$group" "$ver" "$kind"
-    else printf '%s' "$schema"; fi
+    render "$schema" "$group" "$ver" "$4"
     return 0
   done
 
-  render "$TEMPLATE" "$group" "$ver" "$kind"
+  render "https://{domain}/{apiGroup}/{kind_lowercase}_{apiVersion}.json" "$group" "$ver" "$4"
 }
 
-# Insert or update the directive at the start of each doc.
-# Reads per-doc URLs from `urls_file` (one per line; empty line = no change).
 apply_directives() {
-  local file=$1 urls_file=$2
-  awk -v urls_file="$urls_file" '
+  # apply_directives <file> <urls_file>
+  awk -v urls_file="$2" '
     BEGIN {
       i = 0
       while ((getline line < urls_file) > 0) urls[i++] = line
-      close(urls_file)
-      doc = 0; leading = 1; placed = 0
+      doc = 0; lead = 1; placed = 0
     }
-    function emit(    u) {
-      u = urls[doc]
-      if (u != "" && !placed) { print "# yaml-language-server: $schema=" u; placed = 1 }
+    function emit() { if (urls[doc] != "" && !placed) { print "# yaml-language-server: $schema=" urls[doc]; placed = 1 } }
+    /^---[ \t]*$/ { if (lead) emit(); print; doc++; lead = 1; placed = 0; next }
+    lead && !placed && /^[[:space:]]*#[[:space:]]*yaml-language-server:[[:space:]]*[$]schema=/ {
+      cur = $0; sub(/.*[$]schema=/, "", cur); sub(/[[:space:]]+$/, "", cur)
+      if      (cur == urls[doc])     print
+      else if (urls[doc] != "")      print "# yaml-language-server: $schema=" urls[doc]
+      else                           print
+      placed = 1; lead = 0; next
     }
-    /^---[ \t]*$/ {
-      if (leading) emit()
-      print
-      doc++; leading = 1; placed = 0
-      next
-    }
-    leading && !placed && /^[[:space:]]*#[[:space:]]*yaml-language-server:[[:space:]]*[$]schema=/ {
-      cur = $0
-      sub(/.*[$]schema=/, "", cur)
-      sub(/[[:space:]]+$/, "", cur)
-      if (cur == urls[doc])      print
-      else if (urls[doc] != "")  print "# yaml-language-server: $schema=" urls[doc]
-      else                       print
-      placed = 1; leading = 0
-      next
-    }
-    leading && /^[[:space:]]*($|#)/ { print; next }
-    leading {
-      emit()
-      leading = 0
-      print
-      next
-    }
+    lead && /^[[:space:]]*($|#)/ { print; next }
+    lead { emit(); lead = 0; print; next }
     { print }
-    END { if (leading) emit() }
-  ' "$file"
+    END { if (lead) emit() }
+  ' "$1"
 }
 
 process_file() {
-  local file=$1
   local urls=() doc=0 line av kind
   while IFS= read -r line; do
-    [[ -z $line ]] && { urls+=(""); doc=$((doc+1)); continue; }
-    av=$(jq -r '.av   // ""' <<< "$line")
+    av=$(jq -r   '.av // ""' <<< "$line")
     kind=$(jq -r '.kind // ""' <<< "$line")
-    if [[ -z $av || -z $kind || $av == null || $kind == null ]]; then
-      urls+=("")
-    elif [[ $av != */* && $INCLUDE_CORE != "true" ]]; then
-      urls+=("")
+    if [[ -n $av && -n $kind && $av != null && $kind != null ]]; then
+      urls+=("$(choose_schema "$1" "$doc" "$av" "$kind")")
     else
-      urls+=("$(choose_schema "$file" "$doc" "$av" "$kind")")
+      urls+=("")
     fi
     doc=$((doc+1))
-  done < <(yq -o=json -I=0 '{"av": (.apiVersion // ""), "kind": (.kind // "")}' "$file" 2>/dev/null || true)
+  done < <(yq -o=json -I=0 '{"av": (.apiVersion // ""), "kind": (.kind // "")}' "$1" 2>/dev/null || true)
 
   ((${#urls[@]})) || return 0
 
   local urls_file tmp
   urls_file=$(mktemp); printf '%s\n' "${urls[@]}" > "$urls_file"
   tmp=$(mktemp)
-  apply_directives "$file" "$urls_file" > "$tmp"
+  apply_directives "$1" "$urls_file" > "$tmp"
   rm -f "$urls_file"
 
-  if cmp -s "$file" "$tmp"; then
-    rm -f "$tmp"
-    return 0
-  fi
-  mv "$tmp" "$file"
+  cmp -s "$1" "$tmp" && { rm -f "$tmp"; return 0; }
+  mv "$tmp" "$1"
   return 1
 }
 
-changed=0; errors=0
-for file in "${FILES[@]}"; do
-  [[ -f $file ]] || continue
-  rc=0
-  process_file "$file" || rc=$?
+changed=0 errors=0
+for f in "${FILES[@]}"; do
+  [[ -f $f ]] || continue
+  rc=0; process_file "$f" || rc=$?
   case $rc in
-    0) : ;;
-    1) changed=1; echo "k8s-yaml-schema: updated $file" >&2 ;;
-    *) errors=$((errors+1)); echo "k8s-yaml-schema: error processing $file" >&2 ;;
+    0) ;;
+    1) changed=1; echo "k8s-yaml-schema: updated $f" >&2 ;;
+    *) errors=$((errors+1)); echo "k8s-yaml-schema: error processing $f" >&2 ;;
   esac
 done
-
 (( errors > 0 )) && exit 2
 (( changed )) && exit 1 || exit 0

--- a/hooks/test-k8s-yaml-schema.sh
+++ b/hooks/test-k8s-yaml-schema.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Smoke tests for hooks/k8s-yaml-schema. Run from the repo root: `bash hooks/test-k8s-yaml-schema.sh`.
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/k8s-yaml-schema"
+PASS=0
+FAIL=0
+
+run() {
+  local name=$1; shift
+  if "$@"; then
+    PASS=$((PASS+1)); printf '  \033[32mok\033[0m   %s\n' "$name"
+  else
+    FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n' "$name"
+  fi
+}
+
+# --- fixtures ----------------------------------------------------------------
+# Each test runs in its own tmp dir so we can rebuild fixtures cheaply.
+new_workdir() {
+  local d; d=$(mktemp -d)
+  cat > "$d/.k8s-schema-hook.yaml" <<'YAML'
+domain: schemas.example.com
+overrides:
+  - name: kustomize
+    match:
+      apiGroup: kustomize.config.k8s.io
+    schema: https://json.schemastore.org/kustomization
+  - name: helmrelease-app-template
+    match:
+      kind: HelmRelease
+      chartRefOciUrl: oci://ghcr.io/bjw-s-labs/helm/app-template
+    schema: https://{domain}/extras/bjw-s-labs/app-template/helmrelease-helm-v2.schema.json
+YAML
+  printf '%s' "$d"
+}
+
+# --- tests -------------------------------------------------------------------
+
+test_inserts_directive_for_crd() {
+  local d; d=$(new_workdir)
+  cat > "$d/cert.yaml" <<'YAML'
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: foo
+YAML
+  ( cd "$d" && "$HOOK" cert.yaml ) >/dev/null 2>&1
+  local rc=$?
+  [[ $rc -eq 1 ]] || { echo "expected rc=1 (modified), got $rc"; return 1; }
+  grep -qx '# yaml-language-server: $schema=https://schemas.example.com/cert-manager.io/certificate_v1.json' "$d/cert.yaml" \
+    || { echo "directive missing or wrong:"; cat "$d/cert.yaml"; return 1; }
+}
+
+test_idempotent_on_second_run() {
+  local d; d=$(new_workdir)
+  cat > "$d/cert.yaml" <<'YAML'
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: foo
+YAML
+  ( cd "$d" && "$HOOK" cert.yaml ) >/dev/null 2>&1 || true
+  set +e
+  ( cd "$d" && "$HOOK" cert.yaml ) >/dev/null 2>&1
+  local rc=$?
+  set -e
+  [[ $rc -eq 0 ]] || { echo "expected rc=0 on second run, got $rc"; return 1; }
+}
+
+test_applies_kustomize_override() {
+  local d; d=$(new_workdir)
+  cat > "$d/kustomization.yaml" <<'YAML'
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+YAML
+  ( cd "$d" && "$HOOK" kustomization.yaml ) >/dev/null 2>&1 || true
+  grep -qx '# yaml-language-server: $schema=https://json.schemastore.org/kustomization' "$d/kustomization.yaml" \
+    || { echo "override not applied:"; cat "$d/kustomization.yaml"; return 1; }
+}
+
+test_skips_core_by_default() {
+  local d; d=$(new_workdir)
+  cat > "$d/cm.yaml" <<'YAML'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+data: {}
+YAML
+  ( cd "$d" && "$HOOK" cm.yaml ) >/dev/null 2>&1
+  local rc=$?
+  [[ $rc -eq 0 ]] || { echo "expected rc=0 for core resource, got $rc"; return 1; }
+  ! grep -q 'yaml-language-server' "$d/cm.yaml" || { echo "directive unexpectedly inserted:"; cat "$d/cm.yaml"; return 1; }
+}
+
+test_chart_ref_oci_url_override() {
+  local d; d=$(new_workdir)
+  cat > "$d/ocirepository.yaml" <<'YAML'
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+YAML
+  cat > "$d/helmrelease.yaml" <<'YAML'
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: foo
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+YAML
+  ( cd "$d" && "$HOOK" helmrelease.yaml ) >/dev/null 2>&1 || true
+  grep -qx '# yaml-language-server: $schema=https://schemas.example.com/extras/bjw-s-labs/app-template/helmrelease-helm-v2.schema.json' "$d/helmrelease.yaml" \
+    || { echo "chartRefOciUrl override not applied:"; cat "$d/helmrelease.yaml"; return 1; }
+}
+
+test_missing_domain_returns_error() {
+  local d; d=$(mktemp -d)
+  echo "overrides: []" > "$d/.k8s-schema-hook.yaml"
+  cat > "$d/cert.yaml" <<'YAML'
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: foo
+YAML
+  set +e
+  ( cd "$d" && "$HOOK" cert.yaml ) >/dev/null 2>&1
+  local rc=$?
+  set -e
+  [[ $rc -eq 2 ]] || { echo "expected rc=2 on missing domain, got $rc"; return 1; }
+}
+
+test_multi_doc_file() {
+  local d; d=$(new_workdir)
+  cat > "$d/mixed.yaml" <<'YAML'
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: a
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+YAML
+  ( cd "$d" && "$HOOK" mixed.yaml ) >/dev/null 2>&1 || true
+  grep -qF '$schema=https://schemas.example.com/cert-manager.io/certificate_v1.json' "$d/mixed.yaml" \
+    || { echo "first-doc directive missing"; cat "$d/mixed.yaml"; return 1; }
+  grep -qF '$schema=https://json.schemastore.org/kustomization' "$d/mixed.yaml" \
+    || { echo "second-doc directive missing"; cat "$d/mixed.yaml"; return 1; }
+}
+
+# --- run ---------------------------------------------------------------------
+echo "hooks/k8s-yaml-schema smoke tests"
+run "inserts directive for CRD resource"        test_inserts_directive_for_crd
+run "idempotent on second run"                  test_idempotent_on_second_run
+run "applies kustomize override"                test_applies_kustomize_override
+run "skips core resources by default"           test_skips_core_by_default
+run "chartRefOciUrl override looks up sidecar"  test_chart_ref_oci_url_override
+run "missing domain returns error"              test_missing_domain_returns_error
+run "multi-doc file processes each doc"         test_multi_doc_file
+echo
+echo "passed: $PASS  failed: $FAIL"
+exit $(( FAIL > 0 ? 1 : 0 ))


### PR DESCRIPTION
## Summary

Rewrites the schema-directive hook as a single bash script and drops the Python/pre-commit packaging entirely. Focus is lefthook; pre-commit support is gone.

- **`hooks/k8s-yaml-schema`** — single bash file (~175 lines) using `yq` + `jq` + `awk`. Walks YAML files, computes a schema URL per doc from `apiVersion`/`kind` and the override rules, and inserts/updates the `# yaml-language-server: $schema=...` directive in place. Exit codes follow hook conventions: 0 clean, 1 modified, 2 error.
- **`hooks/test-k8s-yaml-schema.sh`** — 7-test smoke suite (pure bash, no bats), wired into CI as a `Hook tests` job.
- **`.k8s-schema-hook.example.yaml`** — annotated example with the kustomize and app-template overrides ready to go.
- **README** gains an "As a git hook" subsection with a lefthook config snippet and a one-liner to vendor the script.

Override matchers retained: `kind`, `apiGroup`, `apiVersion`, `file_regex`, `chartRefOciUrl` (with sidecar `ocirepository.yaml` lookup). The Python-only `jmespath` matcher is gone; it was unused.

Dropped: `pyproject.toml`, `.pre-commit-hooks.yaml`, `hooks/k8s_yaml_schema.py`, `hooks/tests/*.py`, `pytest`, `uv`, `additional_dependencies` plumbing.

## Test plan

- [x] 7/7 smoke tests pass locally (covers default URL, kustomize override, idempotency, core-skip, chartRefOciUrl sidecar lookup, missing-domain error, multi-doc files).
- [ ] CI green.