### PR TITLE
ci: checkout repo in discover job

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,6 +13,11 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Get changed files
         id: changed-files
         uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0


### PR DESCRIPTION
## Summary

The `Discover changed sources` job in `pull-request.yaml` enumerates `sources/*/*/vendir.yml` and `extras/*/*/vendir.yml` via shell globs when an infra change (`scripts/**`, `.mise.toml`, the workflow itself) triggers the "rebuild everything" branch. Without a Checkout step the workspace is empty, both globs expand to themselves, `[[ -f $p ]]` fails on every entry, and the matrix output is `[]` — which silently skips the `Build` job.

This is what happened on PR #17: it touched `scripts/extras.sh` and `.mise.toml` (both infra paths), so the matrix step took the rebuild-all branch and produced an empty matrix. The Build job reported "skipped" / success, so the PR passed CI without actually building anything.

`bjw-s-labs/action-changed-files` only calls the GitHub API for the changed-file list and doesn't touch the workspace, so adding `actions/checkout` is the minimal fix.

## Test plan

- [ ] CI on this PR exercises the infra-changed-rebuild-all branch (this file is an infra path, so the matrix should rebuild every source and every extra).
- [ ] `Build` job actually runs and produces ~34 matrix entries instead of being skipped.