### PR TITLE
feat: compose self-contained app-template HelmRelease schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,24 @@ comment.
 
 ## Extras
 
-A small `extras/` tree lets the same pipeline publish hand-curated JSON
-schemas that aren't CRDs (e.g. the bjw-s app-template HelmRelease schema).
-Each source uses the same `vendir.yml` shape as the CRD sources but the
-build copies the selected files verbatim into `out/site/extras/<owner>/<name>/`.
-Use this for narrow, schema-shaped artifacts only — anything that needs
-rendering or transformation belongs upstream.
+A small `extras/` tree lets the same pipeline publish JSON schemas that
+aren't CRDs. Each source uses the same `vendir.yml` shape as the CRD
+sources. By default the build copies whatever vendir selected, flat, into
+`out/site/extras/<owner>/<name>/`.
+
+For schemas that need transformation, drop an executable `compose.sh`
+alongside the `vendir.yml`. The build invokes it as
+`compose.sh <vendor-dir> <output-dir> <site-dir>` instead of doing a
+verbatim copy, and the script writes the final files into `<output-dir>`.
+`<site-dir>` is the rendered site root so a composer can read other
+schemas this repo publishes (e.g. the Flux HelmRelease schema) and inline
+them.
+
+The bjw-s app-template entry is the canonical example: it vendors the
+common-library schemas, then composes a self-contained HelmRelease v2
+schema with every `$ref` rewritten to an intra-document JSON Pointer —
+which fixes the "yaml-language-server can't follow remote refs" problem
+that plagues the upstream's pre-composed file.
 
 ## Contributing
 

--- a/extras/bjw-s-labs/app-template/compose.sh
+++ b/extras/bjw-s-labs/app-template/compose.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Compose a self-contained HelmRelease v2 schema for the bjw-s app-template chart.
+#
+# Reads every JSON schema from `charts/library/common/{values,schemas/*}` under
+# the vendor dir, parks each one under `$defs/<safe-name>` of our Flux
+# HelmRelease v2 schema, and rewrites every $ref (intra-document, relative,
+# absolute) to an intra-document JSON Pointer. The result has no remote refs,
+# so editors that don't follow cross-document refs still get full completion
+# under .spec.values.
+#
+# Usage: compose.sh <vendor-dir> <output-dir> <site-dir>
+set -euo pipefail
+
+VENDOR="${1:?usage: compose.sh <vendor-dir> <output-dir> <site-dir>}"
+OUTPUT="${2:?usage: compose.sh <vendor-dir> <output-dir> <site-dir>}"
+SITE="${3:?usage: compose.sh <vendor-dir> <output-dir> <site-dir>}"
+
+common_dir="$VENDOR/charts/library/common"
+flux_hr="$SITE/helm.toolkit.fluxcd.io/helmrelease_v2.json"
+
+defs_tmp=$(mktemp)
+trap 'rm -f "$defs_tmp"' EXIT
+
+jq -s '
+  def safe_name:
+    sub(".*?/charts/library/common/"; "")
+    | sub("\\.schema\\.json$"; "")
+    | sub("\\.json$"; "")
+    | gsub("/"; "_")
+  ;
+
+  def rewrite_ref($current; $names):
+    (.["$ref"]) as $ref
+    | (if ($ref | contains("#")) then ($ref | split("#")) else [$ref, ""] end) as $parts
+    | $parts[0] as $url
+    | $parts[1] as $frag
+    | (if $frag != "" then "/" + ($frag | sub("^/"; "")) else "" end) as $fragpath
+    | if $url == "" then
+        .["$ref"] = "#/$defs/" + $names[$current] + $fragpath
+      elif ($url | startswith("http")) and ($names | has($url)) then
+        .["$ref"] = "#/$defs/" + $names[$url] + $fragpath
+      else
+        (($current | sub("/[^/]+$"; "/")) + $url) as $abs
+        | if $names | has($abs) then
+            .["$ref"] = "#/$defs/" + $names[$abs] + $fragpath
+          else . end
+      end
+  ;
+
+  (map({key: .["$id"], value: (.["$id"] | safe_name)}) | from_entries) as $names
+  | map({
+      key: (.["$id"] | safe_name),
+      value: (
+        .["$id"] as $cur
+        | walk(if type == "object" and ((.["$ref"]? // null) | type) == "string"
+               then rewrite_ref($cur; $names) else . end)
+        | del(.["$id"], .["$schema"])
+      )
+    })
+  | from_entries
+' "$common_dir/values.schema.json" "$common_dir/schemas"/*.json > "$defs_tmp"
+
+mkdir -p "$OUTPUT"
+jq --slurpfile defs "$defs_tmp" '
+  .["$defs"] = $defs[0]
+  | .properties.spec.properties.values = {
+      "description": "Values holds the values for this Helm release, constrained to the bjw-s app-template common library schema.",
+      "$ref": "#/$defs/values"
+    }
+' "$flux_hr" > "$OUTPUT/helmrelease-helm-v2.schema.json"
+
+echo "composed $OUTPUT/helmrelease-helm-v2.schema.json" >&2

--- a/extras/bjw-s-labs/app-template/vendir.yml
+++ b/extras/bjw-s-labs/app-template/vendir.yml
@@ -7,6 +7,7 @@ directories:
       - path: .
         git:
           url: https://github.com/bjw-s-labs/helm-charts
-          ref: app-template-5.0.1
+          ref: common-5.0.1
         includePaths:
-          - charts/other/app-template/schemas/*.schema.json
+          - charts/library/common/values.schema.json
+          - charts/library/common/schemas/*.json

--- a/scripts/extras.sh
+++ b/scripts/extras.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Vendor non-CRD JSON Schema assets from a single source into a flat output dir.
+# Vendor non-CRD JSON Schema assets from a single source into an output dir.
 # Usage: extras.sh <source-dir> <output-dir>
 #
-# Reads <source-dir>/vendir.yml, runs `vendir sync` in a scratch dir, and
-# copies every regular file the upstream config selected (via includePaths or
-# asset names) into <output-dir> with its basename. The output is the path
-# served at /extras/<owner>/<name>/ on the published site.
+# Reads <source-dir>/vendir.yml and runs `vendir sync` in a scratch dir. If a
+# `compose.sh` sits next to the vendir.yml, the script is handed the vendor
+# tree, the output dir, and the site dir, and is expected to produce the
+# published files itself; otherwise every regular file vendir selected is
+# copied flat into <output-dir>. The output is what gets served at
+# /extras/<owner>/<name>/.
 
 set -euo pipefail
 shopt -s globstar nullglob
@@ -22,6 +24,11 @@ trap 'rm -rf "$WORK"' EXIT
 
 cp "$SOURCE_DIR/vendir.yml" "$WORK/"
 vendir sync --chdir "$WORK" >&2
+
+if [[ -x "$SOURCE_DIR/compose.sh" ]]; then
+  "$SOURCE_DIR/compose.sh" "$WORK/vendor" "$OUTPUT_DIR" "${OUT_DIR:-out}/site"
+  exit 0
+fi
 
 # vendir auto-includes top-level LICENSE/README from git sources; skip them.
 mapfile -t files < <(find "$WORK/vendor" -mindepth 2 -type f)


### PR DESCRIPTION
## Summary

Replaces the verbatim mirror of bjw-s' `helmrelease-helm-v2.schema.json` with a self-contained schema this repo composes from pieces it already publishes. The composed schema has zero remote `\$refs` — every reference is an intra-document JSON Pointer — so editors that don't follow cross-document refs (the actual complaint about the upstream file) still get full completion under `.spec.values`.

## How

- `extras/<owner>/<name>/` now supports an executable `compose.sh` next to `vendir.yml`. When present, the extras build hands it `<vendor-dir> <output-dir> <site-dir>` and the script writes the final files. The site-dir argument lets composers reuse schemas this repo publishes.
- `extras/bjw-s-labs/app-template/`:
  - `vendir.yml` now vendors `bjw-s-labs/helm-charts` at `common-5.0.1`, pulling `charts/library/common/values.schema.json` and `charts/library/common/schemas/*.json`.
  - `compose.sh` (~50 lines of bash + jq) parks each vendored schema under `\$defs/<safe-name>` of our Flux HelmRelease v2 schema, rewrites every `\$ref` (intra-document, relative, absolute) to an intra-document JSON Pointer, and sets `.spec.values` to `\$ref: "#/\$defs/values"`.

## Test plan

- [x] Composed schema has 20 `\$defs` entries (1 values + 19 sibling schemas) and 229 refs, all intra-document (0 remote).
- [x] Validated a real app-template HelmRelease from a homelab (`Draft202012Validator`) — passes.
- [x] Output stable at `out/site/extras/bjw-s-labs/app-template/helmrelease-helm-v2.schema.json` so the URL doesn't change.
- [x] `mise run all` completes end-to-end.
- [ ] CI green.