### PR TITLE
feat: add node-feature-discovery

### DIFF
--- a/sources/kubernetes-sigs/node-feature-discovery/vendir.yml
+++ b/sources/kubernetes-sigs/node-feature-discovery/vendir.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/kubernetes-sigs/node-feature-discovery
+          ref: v0.18.3
+          includePaths:
+            - deployment/base/nfd-crds/nfd-api-crds.yaml


### PR DESCRIPTION
Adds NFD CRDs (`NodeFeatureRule`, `NodeFeature`, `NodeFeatureGroup`) at `v0.18.3`.

NFD releases ship a Helm chart asset rather than a CRDs-only YAML, so this uses the `git` vendir type pinning `deployment/base/nfd-crds/nfd-api-crds.yaml` from the upstream tree.

## Why

Useful for clusters that pin GPU/NIC/UPS feature flags via `NodeFeatureRule` — three of these live in my home-ops repo and currently 404 against `k8s-schemas.home-operations.com`.

## Source

- Repo: https://github.com/kubernetes-sigs/node-feature-discovery
- Pinned tag: `v0.18.3` (latest stable at time of writing)
- File: `deployment/base/nfd-crds/nfd-api-crds.yaml` (verified present at that tag)