### PR TITLE
feat: add garage-operator

### DIFF
--- a/sources/rajsinghtech/garage-operator/vendir.yml
+++ b/sources/rajsinghtech/garage-operator/vendir.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        githubRelease:
+          slug: rajsinghtech/garage-operator
+          tag: v0.6.17
+          assetNames:
+            - install.yaml
+          disableAutoChecksumValidation: true


### PR DESCRIPTION
Adds CRD schemas for [rajsinghtech/garage-operator](https://github.com/rajsinghtech/garage-operator) (Garage S3-compatible object storage operator).

- Source: `install.yaml` release asset at `v0.6.17`, filtered to `CustomResourceDefinition` docs by the build.
- API group: `garage.rajsingh.info` (versions `v1alpha1`, `v1beta1`, `v1beta2`).
- Kinds: GarageCluster, GarageNode, GarageBucket, GarageKey, GarageAdminToken, GarageReferenceGrant.

Built locally with `scripts/build.sh` — CRDs extract cleanly.