### PR TITLE
feat: add llmkube

### DIFF
--- a/sources/defilantech/LLMKube/vendir.yml
+++ b/sources/defilantech/LLMKube/vendir.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/defilantech/LLMKube
+          ref: v0.8.10
+          skipInitSubmodules: true
+        includePaths:
+          - config/crd/bases/inference.llmkube.dev_*.yaml


### PR DESCRIPTION
Adds CRD schemas for the `inference.llmkube.dev` API group from [defilantech/LLMKube](https://github.com/defilantech/LLMKube) (Kubernetes operator for self-hosted LLM inference).

- Source: git tree at `v0.8.10`, scoped to `config/crd/bases/inference.llmkube.dev_*.yaml` so only the `inference` group is published (the `foreman.llmkube.dev` CRDs are excluded — LLMKube ships no CRD release asset).
- API group: `inference.llmkube.dev` (version `v1alpha1`).
- Kinds: InferenceService, Model, ModelRouter.

Built locally with `scripts/build.sh` — CRDs extract cleanly.