### PR TITLE
feat: add miroir

### DIFF
--- a/sources/home-operations/miroir/vendir.yml
+++ b/sources/home-operations/miroir/vendir.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/home-operations/miroir
+          ref: 0.2.0
+          skipInitSubmodules: true
+        includePaths:
+          - config/crd/bases/*.yaml


### PR DESCRIPTION
Adds CRD schemas for [home-operations/miroir](https://github.com/home-operations/miroir) (replicated block storage CSI driver for small Kubernetes clusters).

- Source: git tree at `0.2.0`, `config/crd/bases/*.yaml`.
- API group: `miroir.home-operations.com` (version `v1alpha1`) — renamed to this group in the 0.2.0 release.
- Kinds: MiroirVolume, MiroirSnapshot, MiroirNode.

Built locally with `scripts/build.sh` — CRDs extract cleanly.