### PR TITLE
ci: tidy workflows (drop explanatory comments, collapse single-command run blocks)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,9 +36,6 @@ jobs:
 
       - name: Build matrix
         id: matrix
-        # Each changed path looks like "sources/<org>/<repo>/(vendir|kind|extract).yaml".
-        # Splitting by '/' and taking [1:3] yields the same owner/repo for
-        # any filename, so unique_by(.name) dedupes when multiple change.
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,9 +37,6 @@ jobs:
 
       - name: Build matrix
         id: matrix
-        # Enumerate sources/<owner>/<repo>/ and pre-compute everything a build
-        # step needs so the matrix step itself is trivial. Same shape as the
-        # discover step in pull-request.yaml.
         run: |
           matrix=$(find sources -mindepth 2 -maxdepth 2 -type d | sort \
             | jq -R -s -c '
@@ -79,10 +76,6 @@ jobs:
           experimental: true
           install_args: --locked
 
-      # Cache vendir's output AND (for kind sources) the extracted CRD YAML
-      # so re-runs short-circuit. Key includes vendir.yml, kind.yaml (if
-      # present), and the build scripts — any change to script logic forces
-      # a clean rebuild instead of reusing a stale output.yaml.
       - name: Restore vendor cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -135,9 +128,6 @@ jobs:
           pattern: crds-*
           merge-multiple: true
 
-      # Built-in types come from a throwaway kind cluster's OpenAPI spec; the
-      # publisher's --openapi mode renders them into the same site and search
-      # index as the CRDs. --kustomize adds the Kustomization schema.
       - name: Dump built-in OpenAPI spec
         run: mise run swagger
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -44,17 +44,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |
-          gh run watch \
-            --repo "${{ github.repository_owner }}/.github" \
-            "${RUN_ID}" \
-            --exit-status
+        run: gh run watch --repo "${{ github.repository_owner }}/.github" "${RUN_ID}" --exit-status
 
       - name: Renovate Output
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
-        run: |-
-          gh run view \
-            --repo "${{ github.repository_owner }}/.github" \
-            --log "${RUN_ID}"
+        run: gh run view --repo "${{ github.repository_owner }}/.github" --log "${RUN_ID}"


### PR DESCRIPTION
Workflow tidy matching [echo#26](https://github.com/home-operations/echo/pull/26) and the e2e-repo rollout — the **comment/format cleanup only** (no e2e parallelization in this PR).

## Changes
- Removed explanatory/rationale comments from the workflows.
- Collapsed single-command multi-line `run:` blocks to one-liners (multi-command blocks left as block scalars).

Functional comments preserved: `# yaml-language-server:`, `# renovate:`, `# zizmor:`.

## Verification
Adversarially reviewed and independently cross-checked: no functional comments removed, YAML valid, and **no `uses:` / `with:` / `env:` / `permissions:` / trigger / logic changes** — comment + run-formatting only. Committed with the pre-commit hooks running (zizmor "No findings", format-yaml clean).
