### PR TITLE
feat: add litellm-operator

### DIFF
--- a/sources/home-operations/litellm-operator/vendir.yml
+++ b/sources/home-operations/litellm-operator/vendir.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/home-operations/litellm-operator
+          ref: 0.0.4
+          skipInitSubmodules: true
+        includePaths:
+          - config/crd/bases/*.yaml


### PR DESCRIPTION
Adds the CRD source for [home-operations/litellm-operator](https://github.com/home-operations/litellm-operator) ("kubernetes native litellm operator"), exposing the `litellm.home-operations.com/v1alpha1` API group.

The release ships no CRDs-only asset, so this is a `git`-type source (matching the sibling `miroir`/`tuppr` sources) sparse-checking `config/crd/bases/*.yaml` at tag `0.0.4`.

Verified locally — the build extracts all four kinds in group `litellm.home-operations.com`, version `v1alpha1`:

- `LiteLLMGuardrail`
- `LiteLLMMCPServer`
- `LiteLLMModel`
- `LiteLLMProxy`

Renovate will bump the `0.0.4` tag on future upstream releases, same as the other sources.