### PR TITLE
feat: publish external JSON schemas (talos, talhelper)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       native: ${{ steps.native-files.outputs.changed_files != '[]' }}
+      external: ${{ steps.external-files.outputs.changed_files != '[]' }}
     steps:
       - name: Get changed files
         id: changed-files
@@ -33,6 +34,14 @@ jobs:
           patterns: |
             native/**
             scripts/builtins-extract.sh
+
+      - name: Get changed external files
+        id: external-files
+        uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: |
+            external/**
+            scripts/external.sh
 
       - name: Build matrix
         id: matrix
@@ -114,11 +123,37 @@ jobs:
           mise run swagger
           crd-schema-publisher convert --openapi out/swagger.json --kustomize -o out/site
 
+  external:
+    if: ${{ needs.changed.outputs.external == 'true' }}
+    needs:
+      - changed
+    name: Build external schemas
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Build external schemas
+        env:
+          VENDIR_GITHUB_API_TOKEN: ${{ github.token }}
+        run: mise run external
+
   status:
     if: ${{ !cancelled() }}
     needs:
       - build
       - native
+      - external
     name: Build Success
     runs-on: ubuntu-24.04
     permissions: {}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths:
       - sources/**
+      - external/**
       - native/**
       - scripts/**
       - .mise.toml
@@ -133,6 +134,11 @@ jobs:
 
       - name: Render merged site
         run: crd-schema-publisher convert -d out/crds --openapi out/swagger.json --kustomize -o out/site --render
+
+      - name: Fetch external schemas
+        env:
+          VENDIR_GITHUB_API_TOKEN: ${{ github.token }}
+        run: mise run external
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -27,6 +27,17 @@ run = "./scripts/build.sh"
 description = "Dump the pinned cluster's OpenAPI spec for native-type schemas"
 run = 'scripts/builtins-extract.sh native "$OUT_DIR/swagger.json"'
 
+[tasks.external]
+description = "Fetch external (non-CRD) JSON schemas into the site"
+run = """
+set -eu
+for dir in external/*/*/; do
+  owner=$(basename "$(dirname "$dir")")
+  repo=$(basename "$dir")
+  ./scripts/external.sh "$dir" "$OUT_DIR/site/external/$owner/$repo"
+done
+"""
+
 [tasks.all]
 description = "Build every source and render the site locally"
 run = """
@@ -39,6 +50,7 @@ for dir in sources/*/*/; do
 done
 scripts/builtins-extract.sh native "$OUT_DIR/swagger.json"
 crd-schema-publisher convert -d "$OUT_DIR/crds" --openapi "$OUT_DIR/swagger.json" --kustomize -o "$OUT_DIR/site" --render
+mise run external
 """
 
 [tasks.clean]

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -8,7 +8,7 @@
       allowedVersions: "<2",
     },
     {
-      description: "Auto-merge CRD upstream bumps",
+      description: "Auto-merge CRD and external schema upstream bumps",
       matchManagers: ["vendir"],
       automerge: true,
       automergeType: "pr",

--- a/README.md
+++ b/README.md
@@ -78,6 +78,30 @@ kind: Kustomization
 # ...
 ```
 
+### External schemas
+
+A small, curated set of GitOps-adjacent tools publish ready-made JSON schemas
+in their own repositories. Those are mirrored verbatim at the pinned upstream
+version under `external/<owner>/<repo>/` — no conversion, just the upstream
+file served from this host:
+
+```yaml
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external/siderolabs/talos/config.schema.json
+version: v1alpha1
+machine:
+# ...
+```
+
+| Tool                 | Schema URL                                      |
+| -------------------- | ----------------------------------------------- |
+| Talos machine config | `external/siderolabs/talos/config.schema.json`  |
+| talhelper            | `external/budimanjojo/talhelper/talconfig.json` |
+
+Each source is a `vendir.yml` under `external/` in this repo, pinned and
+Renovate-bumped exactly like the CRD sources. Only tools that publish a
+maintained JSON schema at a tagged upstream path are in scope — schemas that
+would need generation or hand-maintenance here are not.
+
 ## Contributing
 
 To add a new upstream CRD source:

--- a/external/budimanjojo/talhelper/vendir.yml
+++ b/external/budimanjojo/talhelper/vendir.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/budimanjojo/talhelper
+          ref: v3.1.12
+          skipInitSubmodules: true
+        includePaths:
+          - pkg/config/schemas/talconfig.json

--- a/external/siderolabs/talos/vendir.yml
+++ b/external/siderolabs/talos/vendir.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: vendor
+    contents:
+      - path: .
+        git:
+          url: https://github.com/siderolabs/talos
+          ref: v1.13.5
+          skipInitSubmodules: true
+        includePaths:
+          - pkg/machinery/config/schemas/config.schema.json

--- a/scripts/external.sh
+++ b/scripts/external.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch an external (non-CRD) source's upstream JSON schemas at the pinned
+# version and copy them verbatim into the site. No conversion — upstream
+# already publishes ready-to-use JSON schema files.
+
+SOURCE_DIR="${1:?usage: external.sh <source-dir> <output-dir>}"
+OUTPUT_DIR="${2:?usage: external.sh <source-dir> <output-dir>}"
+SOURCE_DIR="$(cd "${SOURCE_DIR%/}" && pwd)"
+mkdir -p "$OUTPUT_DIR"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp "$SOURCE_DIR/vendir.yml" "$WORK/"
+vendir sync --chdir "$WORK" >&2
+
+found=0
+while IFS= read -r -d '' file; do
+    cp "$file" "$OUTPUT_DIR/"
+    found=1
+done < <(find "$WORK/vendor" -name '*.json' -print0)
+
+[[ "$found" -eq 1 ]] || { echo "no JSON schemas fetched for $SOURCE_DIR" >&2; exit 1; }


### PR DESCRIPTION
## Overview

Publishes upstream JSON schemas for non-CRD tools alongside the CRD schemas, starting with Talos machine config and talhelper as requested in #179.

- New `external/<owner>/<repo>/vendir.yml` sources, pinned to upstream release tags (same pattern as `sources/`), so Renovate picks up version bumps automatically
- `scripts/external.sh` + `mise run external` fetch the schema files via vendir and copy them into the rendered site under `external/<owner>/<repo>/`
- Added into the release workflow (site deploy) and the PR workflow (build validation on changes to `external/**`)

Schemas are served at stable URLs, e.g.:

`https://k8s-schemas.home-operations.com/external/siderolabs/talos/config.schema.json`
`https://k8s-schemas.home-operations.com/external/budimanjojo/talhelper/talconfig.json`

## Additional information

The files are copied as-is (no conversion) and are not listed in the generated site index, they are only reachable via direct URL, documented in the README. 
This works for Talos and Talhelper, but not for Helmfile schema, they are only community maintained in https://github.com/SchemaStore/schemastore without any release tags that could be re-used.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: VSCode Inline Suggestions using GitHub Copilot