### PR TITLE
fix(ci): fail the merge gate on cancelled jobs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -188,10 +188,13 @@ jobs:
     runs-on: ubuntu-24.04
     permissions: {}
     steps:
+      # cancelled counts as failed: !cancelled() above still runs this job when
+      # individual needs were cancelled but the run was not, and a required job
+      # that never reached a verdict must not clear the merge gate.
       - name: Any jobs failed?
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
 
       - name: All jobs passed or skipped?
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: echo "${{ toJSON(needs.*.result) }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,10 +180,13 @@ jobs:
     runs-on: ubuntu-24.04
     permissions: {}
     steps:
+      # cancelled counts as failed: !cancelled() above still runs this job when
+      # individual needs were cancelled but the run was not, and a required job
+      # that never reached a verdict must not clear the merge gate.
       - name: Any jobs failed?
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
 
       - name: All jobs passed or skipped?
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: echo "${{ toJSON(needs.*.result) }}"


### PR DESCRIPTION
The `Build Success` gate treated `cancelled` as passing.

The job runs under `if: ${{ !cancelled() }}`, which still fires when individual `needs` were cancelled but the run as a whole was not. `needs.*.result` then contains `cancelled`, not `failure`, so `Any jobs failed?` is skipped and `All jobs passed or skipped?` exits 0. Branch protection sees the gate green even though a required job never reached a verdict.

Reachable here: `concurrency.cancel-in-progress` is on for `pull_request`, so a superseded push is the ordinary way into that state, not a corner case.

Found while fixing this in home-operations/miroir, then swept the org. Every repo with this aggregator carries it, so there are sibling PRs open elsewhere with the identical change.

Verified: `actionlint` (with the org's `-ignore` flags), `zizmor`, `oxfmt --check`.
